### PR TITLE
feat : 여러 유저의 상태 동기화 기능 구현 

### DIFF
--- a/server.js
+++ b/server.js
@@ -63,11 +63,29 @@ io.on("connection", (socket) => {
         }
     })
 
+    socket.on("myRoomChange",(myRoom,otherPlayerId)=>{
+        console.log("방이 바뀌었나요?");
+        const id = otherPlayerId || socket.id; //방에 자신이 변화를 주었는지 or 남이 변화를 주었는지
+        const player = players.find(player => player.id === id);
+        player.myRoom = myRoom;
+        io.emit("players", players);
+    })
+
     socket.on("disconnecting", () => {
         console.log("연결이 끊어지는 중");
+        const player = players.find(player => player.id === socket.id);
+        if(player){
+            io.emit("exit",{
+                id: socket.id,
+                nickname: player.nickname,
+                jobPosition: player.jobPosition,
+            })
+        }
     });
 
     socket.on("disconnect", (message) => {
         console.log("연결이 끊어짐");
+        players.splice(players.findIndex(player => player.id === socket.id),1);
+        io.emit("players",players);
     });
 });

--- a/server.js
+++ b/server.js
@@ -38,6 +38,16 @@ io.on("connection", (socket) => {
         io.emit("players", players);
     });
 
+    socket.on("move", (position) => {
+        console.log("players", players);
+        const player = players.find(player => player.id === socket.id);
+        if (player) {
+            player.position = position;
+            io.emit("players", players);
+        }
+    });
+
+
     socket.on("disconnecting", () => {
         console.log("연결이 끊어지는 중");
     });

--- a/server.js
+++ b/server.js
@@ -1,20 +1,48 @@
-const {Server} = require('socket.io');
+const {Server} = require("socket.io");
 const io = new Server({
-    cors:{
+    cors: {
         origin: "*",
     },
 });
 
 io.listen(4000);
 
-io.on('connection', (socket) => {
-    console.log('Connected to server');
+/* 입장해 있는 유저들 : 클라이언트의 Socket ID, 캐릭터의 위치좌표, 닉네임, 직군정보, 캐릭터 모델 인덱스, myRoom 배치정보, 메모 정보 */
+const players = [];
 
-    socket.on('disconnecting', () => {
-       console.log("연결이 끊어지는 중");
+io.on("connection", (socket) => {
+    console.log("Connected to server");
+
+    io.emit("players", players);
+    socket.on("initialize", ({tmpNickname, tmpJobPosition, selectedCharacterGlbNameIndex}) => {
+        const newPlayer = {
+            id: socket.id,
+            position: [0, 0, 0],
+            nickname: tmpNickname,
+            jobPosition: tmpJobPosition,
+            selectedCharacterGlbNameIndex: selectedCharacterGlbNameIndex,
+            myRoom: {
+                objects: []
+            }
+        };
+
+        players.push(newPlayer);
+
+        socket.emit("initialize", players.find(player => player.id === socket.id));
+
+        io.emit("enter", {
+            id: socket.id,
+            nickname: newPlayer.nickname,
+            jobPosition: newPlayer.jobPosition,
+        });
+        io.emit("players", players);
     });
 
-    socket.on('disconnect', (message) => {
+    socket.on("disconnecting", () => {
+        console.log("연결이 끊어지는 중");
+    });
+
+    socket.on("disconnect", (message) => {
         console.log("연결이 끊어짐");
     });
-})
+});

--- a/server.js
+++ b/server.js
@@ -47,6 +47,21 @@ io.on("connection", (socket) => {
         }
     });
 
+    socket.on("newText",(text)=>{
+        const sender = players.find(player => player.id === socket.id);
+        if(sender){
+            const {id,nickname,jobPosition} = sender;
+            if(nickname&& jobPosition){
+                io.emit("newText",{
+                    senderId : id,
+                    senderNickname: nickname,
+                    senderJobPosition : jobPosition,
+                    text: text,
+                    timestamp: new Date(),
+                })
+            }
+        }
+    })
 
     socket.on("disconnecting", () => {
         console.log("연결이 끊어지는 중");


### PR DESCRIPTION
## 🔧연결된 이슈
- resolve #1 

## 🛠️작업 내용
### feat: 소켓 서버 초기 설정 및 플레이어 입장/퇴장 기능 구현
- socket.io를 사용한 소켓 서버 설정
- 플레이어 입장 시 초기 위치, 닉네임, 직군, 캐릭터 모델 정보 저장
- 클라이언트에 현재 접속한 플레이어 목록 전달

### feat: 플레이어 이동 이벤트 추가 및 위치 업데이트 기능 구현
- "move" 이벤트 리스너 추가하여 플레이어 위치 변경 처리
- 특정 플레이어의 위치가 업데이트되면 모든 클라이언트에 갱신된 플레이어 목록 전송

### feat: 채팅 메시지와 발신자 정보를 전달하는 `newText` 이벤트 추가
- 클라이언트로부터 수신한 채팅 메시지를 처리하는 `newText` 이벤트 리스너 구현
- 소켓 ID를 기반으로 발신자를 식별하고 닉네임과 직군 정보를 확인
- 발신자 ID, 닉네임, 직군, 메시지 내용, 타임스탬프를 포함하여 모든 클라이언트에 메시지 전송

### feat: 방 상태 변경 및 연결 해제 이벤트 처리 추가
- "myRoomChange" 이벤트 리스너 추가: 사용자가 방 정보를 업데이트할 때 다른 클라이언트들에게 변경 사항을 반영하도록 구현
    - `myRoom` 정보를 변경하고 모든 클라이언트에 최신 `players` 상태 전송
- "disconnecting" 이벤트 리스너 추가: 플레이어 연결이 끊어지는 중일 때, 해당 플레이어의 ID, 닉네임, 직군 정보를 다른 클라이언트에게 전달
- "disconnect" 이벤트 리스너 추가: 플레이어가 연결이 완전히 끊어진 경우 해당 플레이어 정보를 `players` 배열에서 삭제하고 모든 클라이언트에 업데이트 전송


## 🤷‍♂️PR이 필요한 이유
- 이 PR은 서버사이드에서 여러 유저의 상태 동기화 기능(입장/퇴장/채팅/이동/방상태변경) 을 구현하기 위해 존재한다.

## 📸스크린샷 (선택)
- 스크린샷

## 💬리뷰 요구사항(선택)
- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성
